### PR TITLE
将CMAKE_SOURCE_DIR变量更改为CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ include(ProjectBoost)
 configure_project()
 
 # Add project path to include path
-include_directories("${CMAKE_SOURCE_DIR}")
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 
 add_subdirectory(libdevcore)
 add_subdirectory(libinitializer)


### PR DESCRIPTION
解决devkits作为子工程被包含时devkits项目代码无法编译的问题